### PR TITLE
Fixed the broken link to the NatGeo article

### DIFF
--- a/visual-vocabulary/README.md
+++ b/visual-vocabulary/README.md
@@ -19,7 +19,7 @@ The full content of the poster, along with links to related material, including 
 
 ### General
 
-* National Geographic: [Taking data visualisation from eye candy to efficiency](http://news.nationalgeographic.com/2015/09/150922-data-points-visualization-eye-candy-efficiency/)
+* National Geographic: [Taking data visualisation from eye candy to efficiency](https://www.nationalgeographic.com/science/article/150922-data-points-visualization-eye-candy-efficiency)
 * William S. Cleveland and Robert McGill: [Graphical Perception: Theory, Experimentation, and Application to the Development of Graphical Methods](http://info.slis.indiana.edu/~katy/S637-S11/cleveland84.pdf)
 * Hadley Wickham: [A Layered Grammar of Graphics](http://vita.had.co.nz/papers/layered-grammar.pdf)
 * Tracey L. Weissgerber et al: [Beyond Bar and Line Graphs: Time for a New Data Presentation Paradigm](http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1002128)


### PR DESCRIPTION
The link to the National Geographic article: _Taking Data Visualization From Eye Candy to Efficiency_ was broken. This pull requests fixes the link